### PR TITLE
Numba Deprication warning and python fallback fix

### DIFF
--- a/haze_removal.py
+++ b/haze_removal.py
@@ -22,7 +22,7 @@ class HazeRemoval(object):
         
 
     @staticmethod
-    # @jit(nopython=True)
+    @jit(nopython=True)
     def _get_dark_channel(rows,cols,tmp,dark, radius=7):
 
         for i in range(rows):
@@ -54,7 +54,7 @@ class HazeRemoval(object):
         print("time:",time.time()-start)
 
     @staticmethod
-    # @jit(nopython=True)
+    @jit(nopython=True)
     def _get_transmission(rows,cols,Alight,src,tran,radius=7, omega=0.95):
 
         for i in range(rows):


### PR DESCRIPTION
While running the code on with numba 0.18 , I found that the current method does not use numba to compile the code but falls back to python compiler due to depreciation. And thus i have followed this [ref](https://stackoverflow.com/a/52722636/2737811) to make it compatible. Now the warning is gone and the functions with @jit runs faster compared to non-jit version